### PR TITLE
Enabling non-ascii in ToC

### DIFF
--- a/epublib/epub.py
+++ b/epublib/epub.py
@@ -315,7 +315,7 @@ class EpubBook:
         fout = open(os.path.join(self.root_dir, 'META-INF', 'container.xml'), 'wb')
         tmpl = self.loader.load('container.xml')
         stream = tmpl.generate()
-        fout.write(stream.render('xml'))
+        fout.write(stream.render('xml', encoding="utf-8"))
         fout.close()
 
     def _write_toc_ncx(self):
@@ -323,15 +323,15 @@ class EpubBook:
         fout = open(os.path.join(self.root_dir, 'OEBPS', 'toc.ncx'), 'wb')
         tmpl = self.loader.load('toc.ncx')
         stream = tmpl.generate(book=self)
-        fout.write(stream.render('xml'))
+        fout.write(stream.render('xml', encoding="utf-8"))
         fout.close()
 
     def _write_content_opf(self):
         fout = open(os.path.join(self.root_dir, 'OEBPS', 'content.opf'), 'wb')
         tmpl = self.loader.load('content.opf')
         stream = tmpl.generate(book=self)
-        data = stream.render('xml')
-        fout.write(data.encode('utf-8'))
+        data = stream.render('xml', encoding="utf-8")
+        fout.write(data)
         fout.close()
 
     def _write_items(self):


### PR DESCRIPTION
If you have ToC entries with non-ascii characters, current rst2epub will fail; this patch fixes that.