### PR TITLE
Add hook for adding local extensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,38 @@ both epub and mobi files.
 
 Feel free to interact via github for support.
 
+Injecting RST Extensions
+------------------------
+
+Sometimes you need custom RST extensions in a book project.  To let you 
+declare these, rst2epub2 will import a module local_extensions.py that
+sits in the directory it is executed in.  This module should, as a
+side effect of the import, declare directives or text roles.  For 
+instance, the following code would define directive ``article-intro`` (that 
+essentially just attaches a class to the child material):
+
+	from docutils import nodes
+	from docutils.parsers.rst import directives
+	from docutils.parsers import rst
+
+	class _ArticleIntro(rst.Directive):
+		has_content = True
+
+		def run(self):
+			self.assert_has_content()
+			body = "\n".join(self.content)
+			wrapper = nodes.container(rawsource=body)
+			self.state.nested_parse(self.content, 0, wrapper)
+			wrapper["classes"].append("article-intro")
+			return [wrapper]
+
+	directives.register_directive("article-intro", _ArticleIntro)
+
+Note that with this feature someone might make you check out an rstx 
+epub project and then execute arbitrary code while you simply run 
+rst2epub.  We are not sure if that is an expectable attack scenario.
+
+
 Thanks
 ========
 

--- a/rst2epub.py
+++ b/rst2epub.py
@@ -872,6 +872,21 @@ roles.register_local_role("envvar", ignore_role)
 
 
 def main(args=sys.argv):
+		# If there is a file local_extension.py in the local directory,
+		# import it; it is assumed that it will define docutils extensions,
+		# and thus the namespace is discarded.
+		# TODO: Do we want to require a flag so people have to turn on
+		# extensibility manually?
+    if os.path.exists("local_extensions.py"):
+        import imp
+        moddesc = imp.find_module("local_extensions", ["."])
+        imp.acquire_lock()
+        try:
+            modNs = imp.load_module("local_extensions", *moddesc)
+        finally:
+            imp.release_lock()
+
+
     argv = None
     reader = standalone.Reader()
     reader_name = "standalone"


### PR DESCRIPTION
This patch lets rst2epub execute a local_extensions.py module that is in the current directory.

The idea is that people can add RST extension through that mechanism.  The downside is that if someone gets a victim to check out a repo (or untar a zip) and tells them to run rst2epub on it, the victims might not be aware that they've given the attackers the right to execute arbitrary code on their machine.  I consider this a bit far-fetched, but perhaps we should still add a flag ("--execute-localext") and only read local_extensions.py if that flag is given?