### PR TITLE
epublib: epub: raise Exception if no title is passed to TOC

### DIFF
--- a/epublib/epub.py
+++ b/epublib/epub.py
@@ -302,9 +302,8 @@ class EpubBook:
 
     def add_toc_map_node(self, href, title, depth=None, parent=None):
         if not title:
-            import pdb
-
-            pdb.set_trace()
+            raise ValueError("Missing title. Did you forgot an header "
+                             "before the first paragraph?")
         print("TITLE", title)
         node = TocMapNode()
         node.href = href


### PR DESCRIPTION
I have spent some time to understand why this master release of
rst2epub2 was not generating an epub against the same source file while
the stable 0.3.1 PyPI release was working fine.

Turns out I was entering this branch because my document did not have a
h1 (but in rst) before the first paragraph, making it look like an
introduction. After inspecting the generated EPUB file of the 0.3.1
version, it seems that the generation was wrong with empty a tags
into the EPUB's TOC.

By raising a sensible exception instead of firing up a pdb instance, we
may help end users realize that EPUB documents are less flexible than
pure HTML and require a proper title before any paragraph can be
introduced for the TOC to make sense.

Signed-off-by: Romain Porte <microjoe@microjoe.org>