### PR TITLE
Making the language meta actually call set_lang.

### DIFF
--- a/rst2epub.py
+++ b/rst2epub.py
@@ -657,6 +657,8 @@ book will follow suit.</paragraph></footnote>
                 self.book.add_creator(v)
             elif k.lower() == "title":
                 self.book.set_title(v)
+            elif k.lower() == 'language':
+                self.book.set_lang(v)
             else:
                 self.book.add_meta(k, v)
         self.book.add_creator(", ".join(self.authors))
@@ -673,7 +675,7 @@ book will follow suit.</paragraph></footnote>
 XHTML_WRAPPER = u"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
 "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title>{title}</title>
 <meta http-equiv="Content-type" content="application/xhtml+xml;charset=utf8" />


### PR DESCRIPTION
Also, removing unwarranted xml:lang in the template -- it's better
to say nothing than to lie.

Without this, the generated e-books will always declare en-us, with whatever is passed in in language as a second.  This typically causes bad hyphenation patterns to be used.

As to xml:lang: Let's not claim anything we don't know for a fact.  Language autodetection is pretty good these days, so we're probably going to spoil more that we might possibly fix.